### PR TITLE
build: replace node-plantuml with node-plantuml-back

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import visit from "unist-util-visit";
-import plantuml from "node-plantuml";
+import plantuml from "node-plantuml-back";
 
 /**
  * Plugin for remark-js

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "node-plantuml": "^0.9.0",
+        "node-plantuml-back": "^1.1.4",
         "unist-util-visit": "^2.0.2"
       },
       "devDependencies": {
@@ -2858,33 +2858,37 @@
         "node-nailgun-client": "index.js"
       }
     },
-    "node_modules/node-nailgun-server": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.4.tgz",
-      "integrity": "sha512-e0Hbh6XPb/7GqATJ45BePaUEO5AwR7InRW/pGeMKHH1cqPMBFCeqdBNfvi+bkVLnsbYOOQE+pAek9nmNoD8sYw==",
+    "node_modules/node-plantuml-back": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-plantuml-back/-/node-plantuml-back-1.1.4.tgz",
+      "integrity": "sha512-HKgt2jctutB1EFax9UytlaBQYjb8oo3TOLzDCEj4Il0/kOzDo0jTae3V74sn3No9fgID4CU3azmBrq7hdM0+Jg==",
       "dependencies": {
-        "commander": "^2.8.1"
-      },
-      "bin": {
-        "node-nailgun-server": "index.js"
-      }
-    },
-    "node_modules/node-plantuml": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.9.0.tgz",
-      "integrity": "sha512-bUnntTGjbpYu1pvXZI/GS6ctcXf3AOMqJxBMO8vFzTT5RwH8Cj/J5Ca6Dy+PEfMiMDdSBCFKSGnvYyBvYnucXg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "commander": "^2.8.1",
-        "node-nailgun-client": "^0.1.0",
-        "node-nailgun-server": "^0.1.4",
-        "plantuml-encoder": "^1.2.5"
+        "commander": "^11.x",
+        "node-nailgun-client": "^0.1.2",
+        "node-nailgun-server": "^0.3.0",
+        "plantuml-encoder": "^1.4.0"
       },
       "bin": {
         "puml": "index.js"
       },
       "engines": {
         "node": ">= 6.x"
+      }
+    },
+    "node_modules/node-plantuml-back/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/node-plantuml-back/node_modules/node-nailgun-server": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.3.0.tgz",
+      "integrity": "sha512-jiVQheazpL4ENevhIhw6wYKCb9UYuBTOQ0v85t2vMjur16CFPVK3fKQ3K8vSe3K6+72iI4aPpvm5g7dhRJtPfw==",
+      "engines": {
+        "node": ">= 8.x"
       }
     },
     "node_modules/node-preload": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "remark": "^11.0.2"
   },
   "dependencies": {
-    "node-plantuml": "^0.9.0",
+    "node-plantuml-back": "^1.1.4",
     "unist-util-visit": "^2.0.2"
   },
   "publishConfig": {


### PR DESCRIPTION
Since [node-plantuml](https://github.com/markushedvall/node-plantuml) seems to be unmaintained, I replaced that dependency with [node-plantuml-back](https://www.npmjs.com/package/node-plantuml-back), last updated 3 months ago, which has a recent PlantUML version [declared in the package.json file](https://github.com/vowstar/node-plantuml-back/blob/8aef650a4decb0f785f074aeef08698fe11e2bcd/package.json#L4). 