### PR TITLE
fix: set default JVM heap limit to prevent OOM crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ import plantuml from "node-plantuml-back";
  * https://github.com/unifiedjs/unified#plugin
  */
 function remarkLocalPlantumlPlugin() {
+  if (!process.env.JAVA_TOOL_OPTIONS) {
+    process.env.JAVA_TOOL_OPTIONS = "-Xmx512m";
+  }
+
   return async function transformer(syntaxTree) {
     const nodes = [];
     visit(syntaxTree, "code", (node) => {


### PR DESCRIPTION
node-plantuml-back spawns Java without memory limits, causing the JVM to request ~768MB upfront which can fail with an OOM error and produce hs_err_pid*.log crash dumps.

Set JAVA_TOOL_OPTIONS=-Xmx512m as a default if not already configured by the user. 512MB is sufficient for PlantUML rendering.