### PR TITLE
ci: use npm provenance for release publish

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Publish to npm
         run: |
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            npm publish --tag beta
+            npm publish --tag beta --provenance
           else
-            npm publish
+            npm publish --provenance
           fi


### PR DESCRIPTION
## Summary
- update release publish command to use npm provenance
- keep prerelease behavior with beta tag

## Why
- align GitHub Actions release publishing with npm trusted publishing setup